### PR TITLE
Fix missing FlutterActivity in manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -35,6 +35,12 @@
         <activity
             android:name=".activity.GameActivity"
             android:exported="false" />
+        <!-- Activity used to display Flutter content when launched from AlarmActivity -->
+        <activity
+            android:name="io.flutter.embedding.android.FlutterActivity"
+            android:exported="false"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:hardwareAccelerated="true" />
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"


### PR DESCRIPTION
## Summary
- add missing FlutterActivity entry in `AndroidManifest.xml` so AlarmActivity can open the Flutter screen with a cached engine

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed95c8efc8330a66f7689a40bcca7