### PR TITLE
Remove invalid initialRoute builder call

### DIFF
--- a/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/activity/AlarmActivity.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/activity/AlarmActivity.kt
@@ -73,9 +73,11 @@ class AlarmActivity : ComponentActivity() {
                             alarmNotificationService.cancelNotification(alarmId)
                             
                             // Launch Flutter game screen using the cached engine
+                            // Since initialRoute can't be set on a cached engine,
+                            // push the desired route before launching the activity
+                            flutterEngine?.navigationChannel?.pushRoute("/game")
                             val gameIntent =
                                 FlutterActivity.withCachedEngine(ENGINE_ID)
-                                    .initialRoute("/game")
                                     .build(this@AlarmActivity)
                             startActivity(gameIntent)
                             finish()


### PR DESCRIPTION
## Summary
- fix AlarmActivity build error by removing unavailable `initialRoute` call for cached engines
- push the game route programmatically instead

## Testing
- `./gradlew test --stacktrace` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686eed4d69d083308d99a932f077ebd9