### PR TITLE
Fix missing FlutterActivity manifest entry

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -60,6 +60,15 @@
             </intent-filter>
         </activity>
 
+        <!-- Declare FlutterActivity so it can be launched with a cached engine -->
+        <activity
+            android:name="io.flutter.embedding.android.FlutterActivity"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:exported="false"
+            android:hardwareAccelerated="true"
+            android:theme="@style/LaunchTheme"
+            android:windowSoftInputMode="adjustResize" />
+
         <receiver
             android:name=".receiver.AlarmReceiver"
             android:enabled="true"


### PR DESCRIPTION
## Summary
- declare `io.flutter.embedding.android.FlutterActivity` in Android manifest so the cached engine activity can be launched

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686eeeea6514833097d60a847d51fd2d