### PR TITLE
Fix Sky Tower stuck on loading

### DIFF
--- a/lib/sky_tower_game_screen.dart
+++ b/lib/sky_tower_game_screen.dart
@@ -55,7 +55,9 @@ class _SkyTowerGameScreenState extends State<SkyTowerGameScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        _screenSize = MediaQuery.of(context).size;
+        setState(() {
+          _screenSize = MediaQuery.of(context).size;
+        });
         // resetGame() will now be called from build method once _screenSize is available
       }
     });


### PR DESCRIPTION
## Summary
- ensure Sky Tower game screen rebuilds after getting screen size

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700674b7408330ba53cc82b58c724f