### PR TITLE
Fix SkyTower layout refresh

### DIFF
--- a/lib/sky_tower_game_screen.dart
+++ b/lib/sky_tower_game_screen.dart
@@ -50,13 +50,24 @@ class _SkyTowerGameScreenState extends State<SkyTowerGameScreen> {
   Size? _screenSize;
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final newSize = MediaQuery.of(context).size;
+    if (_screenSize == null || _screenSize != newSize) {
+      _screenSize = newSize;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          resetGame();
+        }
+      });
+    }
+  }
+
+  @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        setState(() {
-          _screenSize = MediaQuery.of(context).size;
-        });
+      if (mounted && _screenSize != null) {
         resetGame();
       }
     });


### PR DESCRIPTION
## Summary
- recompute screen size in `didChangeDependencies`
- only reset the game once size is known

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700e91ca3c83308a3c1a3b02a565e6