### PR TITLE
Fix Sky Tower layout bottom offset

### DIFF
--- a/lib/sky_tower_game_screen.dart
+++ b/lib/sky_tower_game_screen.dart
@@ -178,7 +178,9 @@ class _SkyTowerGameScreenState extends State<SkyTowerGameScreen> {
     }
 
 
-    final gameWidth = _screenSize!.width;
+    final mediaQuery = MediaQuery.of(context);
+    final gameWidth = mediaQuery.size.width;
+    final gameHeight = mediaQuery.size.height - mediaQuery.padding.bottom;
 
     return Scaffold(
       backgroundColor: const Color(0xFF0f0f0f),
@@ -191,7 +193,7 @@ class _SkyTowerGameScreenState extends State<SkyTowerGameScreen> {
               alignment: Alignment.center,
               child: Container(
                 width: gameWidth,
-                height: _screenSize!.height,
+                height: gameHeight,
                 color: const Color(0xFF1a1a1a),
                 child: Stack(
                   clipBehavior: Clip.none,


### PR DESCRIPTION
## Summary
- adjust game area height in Sky Tower to account for bottom padding

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687010b3cc9083309f6fdd6c08f0b666