### PR TITLE
Fix Sky Tower base offset

### DIFF
--- a/lib/sky_tower_game_screen.dart
+++ b/lib/sky_tower_game_screen.dart
@@ -180,7 +180,7 @@ class _SkyTowerGameScreenState extends State<SkyTowerGameScreen> {
 
     final mediaQuery = MediaQuery.of(context);
     final gameWidth = mediaQuery.size.width;
-    final gameHeight = mediaQuery.size.height - mediaQuery.padding.bottom;
+    final gameHeight = mediaQuery.size.height - mediaQuery.padding.vertical;
 
     return Scaffold(
       backgroundColor: const Color(0xFF0f0f0f),
@@ -190,7 +190,7 @@ class _SkyTowerGameScreenState extends State<SkyTowerGameScreen> {
           children: [
             // Game Area
             Align(
-              alignment: Alignment.center,
+              alignment: Alignment.bottomCenter,
               child: Container(
                 width: gameWidth,
                 height: gameHeight,


### PR DESCRIPTION
## Summary
- fix vertical padding calculation
- align game area bottom to screen bottom in the Sky Tower game

## Testing
- `dart format lib/sky_tower_game_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687014200fb48330afdaab55b9a63e6f