### PR TITLE
Fix sky tower safe area offset

### DIFF
--- a/lib/sky_tower_game_screen.dart
+++ b/lib/sky_tower_game_screen.dart
@@ -180,7 +180,10 @@ class _SkyTowerGameScreenState extends State<SkyTowerGameScreen> {
 
     final mediaQuery = MediaQuery.of(context);
     final gameWidth = mediaQuery.size.width;
-    final gameHeight = mediaQuery.size.height - mediaQuery.padding.vertical;
+    // Use the full height minus the top padding. The bottom padding
+    // will be handled by explicit padding to keep the ground visible
+    // on devices with system navigation bars.
+    final gameHeight = mediaQuery.size.height - mediaQuery.padding.top;
 
     return Scaffold(
       backgroundColor: const Color(0xFF0f0f0f),
@@ -189,13 +192,15 @@ class _SkyTowerGameScreenState extends State<SkyTowerGameScreen> {
         child: Stack(
           children: [
             // Game Area
-            Align(
-              alignment: Alignment.bottomCenter,
-              child: Container(
-                width: gameWidth,
-                height: gameHeight,
-                color: const Color(0xFF1a1a1a),
-                child: Stack(
+            Padding(
+              padding: EdgeInsets.only(bottom: mediaQuery.padding.bottom),
+              child: Align(
+                alignment: Alignment.bottomCenter,
+                child: Container(
+                  width: gameWidth,
+                  height: gameHeight,
+                  color: const Color(0xFF1a1a1a),
+                  child: Stack(
                   clipBehavior: Clip.none,
                   children: [
                     // Tower Blocks


### PR DESCRIPTION
## Summary
- keep tower floor visible by padding bottom with safe area
- clean up indentation

## Testing
- `flutter test` *(fails: `flutter` command not found)*
- `dart format lib/sky_tower_game_screen.dart` *(fails: `dart` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870159d3f7c8330905f98718e626d10