### PR TITLE
Fix screen size init in SkyTower

### DIFF
--- a/lib/sky_tower_game_screen.dart
+++ b/lib/sky_tower_game_screen.dart
@@ -53,9 +53,15 @@ class _SkyTowerGameScreenState extends State<SkyTowerGameScreen> {
   @override
   void initState() {
     super.initState();
-    // Initialize _screenSize directly in initState
-    _screenSize = WidgetsBinding.instance.window.physicalSize / WidgetsBinding.instance.window.devicePixelRatio;
-    resetGame();
+    // Obtain screen size after first frame so MediaQuery is available
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        setState(() {
+          _screenSize = MediaQuery.of(context).size;
+        });
+        resetGame();
+      }
+    });
   }
 
   @override


### PR DESCRIPTION
## Summary
- ensure Sky Tower blocks are visible by capturing screen size after the first frame

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68701b7173dc8330b15f3f3c0e06f4fe