### PR TITLE
Expand wall bounce game to use full screen

### DIFF
--- a/lib/wall_bounce_flutter.dart
+++ b/lib/wall_bounce_flutter.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'dart:async';
 import 'dart:math' as math;
 
-const double GAME_WIDTH = 400;
-const double GAME_HEIGHT = 600;
+double gameWidth = 400;
+double gameHeight = 600;
 const double WALL_WIDTH = 40;
 const double PLAYER_SIZE = 26;
 const double GRAVITY = 0.6;
@@ -109,6 +109,7 @@ class _WallBounceGameState extends State<WallBounceGame> with TickerProviderStat
   
   Timer? gameTimer;
   final math.Random random = math.Random();
+  bool _sizeInitialized = false;
 
   @override
   void initState() {
@@ -116,12 +117,26 @@ class _WallBounceGameState extends State<WallBounceGame> with TickerProviderStat
     _initializeGame();
   }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_sizeInitialized) {
+      final size = MediaQuery.of(context).size;
+      setState(() {
+        gameWidth = size.width;
+        gameHeight = size.height;
+        _initializeGame();
+        _sizeInitialized = true;
+      });
+    }
+  }
+
   void _initializeGame() {
     player = Player(
       x: WALL_WIDTH,
-      y: WORLD_FLOOR - GAME_HEIGHT * (1 - PLAYER_SCREEN_RATIO),
+      y: WORLD_FLOOR - gameHeight * (1 - PLAYER_SCREEN_RATIO),
     );
-    camera = Camera(y: WORLD_FLOOR - GAME_HEIGHT);
+    camera = Camera(y: WORLD_FLOOR - gameHeight);
     obstacles.clear();
     diamonds.clear();
     score = 0;
@@ -143,8 +158,8 @@ class _WallBounceGameState extends State<WallBounceGame> with TickerProviderStat
         obstacles.add(GameObstacle(
           id: random.nextDouble(),
           x: random.nextBool() 
-            ? WALL_WIDTH + 5 
-            : GAME_WIDTH - WALL_WIDTH - OBSTACLE_SIZE - 5,
+            ? WALL_WIDTH + 5
+            : gameWidth - WALL_WIDTH - OBSTACLE_SIZE - 5,
           y: y + random.nextDouble() * 80 - 40,
         ));
       }
@@ -152,7 +167,7 @@ class _WallBounceGameState extends State<WallBounceGame> with TickerProviderStat
       if (random.nextDouble() < 0.9) {
         bool isDanger = random.nextDouble() < 0.2;
         double minX = WALL_WIDTH + 20;
-        double maxX = GAME_WIDTH - WALL_WIDTH - DIAMOND_SIZE - 20;
+        double maxX = gameWidth - WALL_WIDTH - DIAMOND_SIZE - 20;
         diamonds.add(GameDiamond(
           id: random.nextDouble(),
           x: minX + random.nextDouble() * (maxX - minX),
@@ -163,7 +178,7 @@ class _WallBounceGameState extends State<WallBounceGame> with TickerProviderStat
       
       if (y % 240 == 0 && random.nextDouble() < 0.7) {
         bool isDanger = random.nextDouble() < 0.15;
-        double centerX = GAME_WIDTH / 2 - DIAMOND_SIZE / 2;
+        double centerX = gameWidth / 2 - DIAMOND_SIZE / 2;
         diamonds.add(GameDiamond(
           id: random.nextDouble(),
           x: centerX + random.nextDouble() * 60 - 30,
@@ -251,8 +266,8 @@ class _WallBounceGameState extends State<WallBounceGame> with TickerProviderStat
             }
           }
           
-          if (newX >= GAME_WIDTH - WALL_WIDTH - PLAYER_SIZE) {
-            newX = GAME_WIDTH - WALL_WIDTH - PLAYER_SIZE;
+          if (newX >= gameWidth - WALL_WIDTH - PLAYER_SIZE) {
+            newX = gameWidth - WALL_WIDTH - PLAYER_SIZE;
             if (newVx > 0) {
               newVx = 0;
               newVy = newVy * WALL_BOUNCE_DAMPING;
@@ -284,10 +299,10 @@ class _WallBounceGameState extends State<WallBounceGame> with TickerProviderStat
         }
 
         // Update camera
-        double screenPos = camera.y + GAME_HEIGHT * PLAYER_SCREEN_RATIO;
+        double screenPos = camera.y + gameHeight * PLAYER_SCREEN_RATIO;
         if (player.y < screenPos) {
-          double targetY = player.y - GAME_HEIGHT * PLAYER_SCREEN_RATIO;
-          double clampedY = math.min(WORLD_FLOOR - GAME_HEIGHT, targetY);
+          double targetY = player.y - gameHeight * PLAYER_SCREEN_RATIO;
+          double clampedY = math.min(WORLD_FLOOR - gameHeight, targetY);
           double smoothFactor = 0.1;
           camera.y = camera.y + (clampedY - camera.y) * smoothFactor;
         }
@@ -326,13 +341,19 @@ class _WallBounceGameState extends State<WallBounceGame> with TickerProviderStat
   }
 
   List<GameObstacle> _getVisibleObstacles() {
-    return obstacles.where((obs) =>
-        obs.y >= camera.y - OBSTACLE_SIZE && obs.y <= camera.y + GAME_HEIGHT + OBSTACLE_SIZE).toList();
+    return obstacles
+        .where((obs) =>
+            obs.y >= camera.y - OBSTACLE_SIZE &&
+            obs.y <= camera.y + gameHeight + OBSTACLE_SIZE)
+        .toList();
   }
 
   List<GameDiamond> _getVisibleDiamonds() {
-    return diamonds.where((d) =>
-        d.y >= camera.y - DIAMOND_SIZE && d.y <= camera.y + GAME_HEIGHT + DIAMOND_SIZE).toList();
+    return diamonds
+        .where((d) =>
+            d.y >= camera.y - DIAMOND_SIZE &&
+            d.y <= camera.y + gameHeight + DIAMOND_SIZE)
+        .toList();
   }
 
   @override
@@ -345,8 +366,8 @@ class _WallBounceGameState extends State<WallBounceGame> with TickerProviderStat
           child: GestureDetector(
             onTap: _handleJump,
             child: Container(
-              width: GAME_WIDTH,
-              height: GAME_HEIGHT,
+              width: gameWidth,
+              height: gameHeight,
               decoration: BoxDecoration(
                 color: const Color(0xFF111827),
                 border: Border.all(color: const Color(0xFF374151), width: 4),
@@ -536,7 +557,7 @@ class GamePainter extends CustomPainter {
     );
     canvas.drawRect(
       Rect.fromLTWH(
-        GAME_WIDTH - WALL_WIDTH,
+        gameWidth - WALL_WIDTH,
         worldTop - camera.y,
         WALL_WIDTH,
         WORLD_FLOOR - worldTop,


### PR DESCRIPTION
## Summary
- make game width and height dynamic so the wall bounce game uses the device screen
- reinitialize the game with screen size using `didChangeDependencies`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702b9610c08330b670be04a4b9046a