### PR TITLE
Fix cameraY assignment

### DIFF
--- a/lib/icy_tower_flutter.dart
+++ b/lib/icy_tower_flutter.dart
@@ -414,7 +414,8 @@ class _IcyTowerGameScreenState extends State<IcyTowerGameScreen> {
   }
 
   void _updateCamera(double gameHeight) {
-    final targetCameraY = max(gameHeight * 0.4 - ball.y, 0);
+    final double targetCameraY =
+        max(gameHeight * 0.4 - ball.y, 0).toDouble();
     if ((targetCameraY - cameraY).abs() > 1) {
       cameraY = targetCameraY;
     }


### PR DESCRIPTION
## Summary
- fix type mismatch when updating the camera position

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687161f959108330a6277d01c2007d56