### PR TITLE
Fix Icy Tower jump controls

### DIFF
--- a/lib/icy_tower_flutter.dart
+++ b/lib/icy_tower_flutter.dart
@@ -443,7 +443,8 @@ class _IcyTowerGameScreenState extends State<IcyTowerGameScreen> {
     final tapX = details.localPosition.dx;
     final newVX = tapX < _screenSize!.width / 2 ? -horizontalSpeed : horizontalSpeed;
 
-    ball = ball.copyWith(vx: newVX);
+    // Apply a jump in the chosen direction
+    ball = ball.copyWith(vx: newVX, vy: jumpForce);
   }
 
   void _resetGame() {


### PR DESCRIPTION
## Summary
- update Icy Tower `_handleTap` so touching screen halves makes the character jump left or right

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68716f5e71ec83308e9447e7e9f130a0