### PR TITLE
Fix Icy Tower controls

### DIFF
--- a/lib/icy_tower_flutter.dart
+++ b/lib/icy_tower_flutter.dart
@@ -452,8 +452,13 @@ class _IcyTowerGameScreenState extends State<IcyTowerGameScreen> {
     if (gameOver || isPaused) return;
 
     if (_screenSize != null) {
+      final isLeft = details.localPosition.dx < _screenSize!.width / 2;
+
       // Store the input, to be applied on the next jump
-      _pendingHorizontalInput = details.localPosition.dx < _screenSize!.width / 2 ? -1 : 1;
+      _pendingHorizontalInput = isLeft ? -1 : 1;
+
+      // Immediately update horizontal velocity for more responsive control
+      ball = ball.copyWith(vx: _pendingHorizontalInput * horizontalSpeed);
     }
   }
 


### PR DESCRIPTION
## Summary
- improve tap handling so jumps respond immediately

## Testing
- `dart format lib/icy_tower_flutter.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687171cc57a083309aee0b7b49676b63