### PR TITLE
Fix control scheme in Icy Tower

### DIFF
--- a/lib/icy_tower_flutter.dart
+++ b/lib/icy_tower_flutter.dart
@@ -454,8 +454,8 @@ class _IcyTowerGameScreenState extends State<IcyTowerGameScreen> {
     if (_screenSize != null) {
       final isLeft = details.localPosition.dx < _screenSize!.width / 2;
 
-      // Store the input, to be applied on the next jump
-      _pendingHorizontalInput = isLeft ? -1 : 1;
+      // Invert controls: tap right to jump left and tap left to jump right
+      _pendingHorizontalInput = isLeft ? 1 : -1;
 
       // Immediately apply jump with directional velocity
       ball = ball.copyWith(


### PR DESCRIPTION
## Summary
- invert controls so tapping one side moves the ball to the opposite side

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687177ea3a548330b0bf3b1e7bbec169