### PR TITLE
Implement auto restart for memory match

### DIFF
--- a/lib/memory_match_flutter.dart
+++ b/lib/memory_match_flutter.dart
@@ -66,6 +66,7 @@ class _MemoryMatchGameScreenState extends State<MemoryMatchGameScreen> {
   Timer? _patternTimer;
   Timer? _matchTimer;
   Timer? _countdownTimer;
+  Timer? _gameOverTimer;
 
   @override
   void initState() {
@@ -78,6 +79,7 @@ class _MemoryMatchGameScreenState extends State<MemoryMatchGameScreen> {
     _patternTimer?.cancel();
     _matchTimer?.cancel();
     _countdownTimer?.cancel();
+    _gameOverTimer?.cancel();
     super.dispose();
   }
 
@@ -148,6 +150,8 @@ class _MemoryMatchGameScreenState extends State<MemoryMatchGameScreen> {
             // Check if game is complete
             if (matches == totalPairs) {
               gameOver = true;
+              _gameOverTimer =
+                  Timer(const Duration(seconds: 5), () => resetGame());
             }
 
             flippedCards.clear();
@@ -170,6 +174,7 @@ class _MemoryMatchGameScreenState extends State<MemoryMatchGameScreen> {
     _patternTimer?.cancel();
     _matchTimer?.cancel();
     _countdownTimer?.cancel();
+    _gameOverTimer?.cancel();
 
     setState(() {
       cards = generateCards();


### PR DESCRIPTION
## Summary
- automatically restart Memory Match after victory

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872436507bc8330b0475a732a9bfded