### PR TITLE
Improve alarm scheduling reliability

### DIFF
--- a/lib/alarm_settings_screen.dart
+++ b/lib/alarm_settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:intl/intl.dart';
 import 'hive/models/alarm_settings.dart';
 import 'hive/service/database_service.dart';
 import 'services/alarm_scheduler_service.dart';
+import 'utils/alarm_method_channel.dart';
 
 class AlarmSettingsScreen extends StatefulWidget {
   const AlarmSettingsScreen({super.key});
@@ -357,6 +358,16 @@ class _AlarmSettingsScreenState extends State<AlarmSettingsScreen> {
 
     // Zapisz alarm
     await DatabaseService.instance.saveAlarmSettings(alarmSettings);
+
+    // Schedule the native alarm immediately for the next occurrence
+    AlarmMethodChannel.scheduleNativeAlarm({
+      'id': alarmSettings.id,
+      'name': alarmSettings.name,
+      'hour': alarmSettings.hour,
+      'minute': alarmSettings.minute,
+      'gameType': alarmSettings.gameType,
+      'selectedDays': alarmSettings.selectedDays,
+    });
     
     // Odśwież scheduler
     AlarmSchedulerService.instance.refreshAlarms();

--- a/lib/services/alarm_scheduler_service.dart
+++ b/lib/services/alarm_scheduler_service.dart
@@ -65,7 +65,19 @@ class AlarmSchedulerService {
         .getAllAlarmSettings()
         .where((alarm) => alarm.isEnabled)
         .toList();
-    log('Loaded  [32m [1m [4m [7m${_activeAlarms.length} [0m active alarms: ${_activeAlarms.map((a) => a.name).toList()}');
+    log('Loaded ${_activeAlarms.length} active alarms: ${_activeAlarms.map((a) => a.name).toList()}');
+
+    // Schedule each active alarm using the native AlarmManager
+    for (final alarm in _activeAlarms) {
+      AlarmMethodChannel.scheduleNativeAlarm({
+        'id': alarm.id,
+        'name': alarm.name,
+        'hour': alarm.hour,
+        'minute': alarm.minute,
+        'gameType': alarm.gameType,
+        'selectedDays': alarm.selectedDays.toList(),
+      });
+    }
   }
 
   // Schedule next check for alarms


### PR DESCRIPTION
## Summary
- schedule Android alarms as soon as they're saved
- schedule alarms when refreshing active alarms

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68774488863c833087f8ec0d8700bfd9