### PR TITLE
Fix game type and duration in alarm workflow

### DIFF
--- a/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/MethodChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/MethodChannelHandler.kt
@@ -37,6 +37,7 @@ class MethodChannelHandler(private val context: Context) {
                 val intent = Intent(context, AlarmFlutterActivity::class.java).apply {
                     putExtra("alarmTime", System.currentTimeMillis())
                     putExtra("gameType", "piano_tiles") // This can be made dynamic
+                    putExtra("durationMinutes", 1)
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
                 }
                 context.startActivity(intent)
@@ -54,13 +55,15 @@ class MethodChannelHandler(private val context: Context) {
         val minute = (alarmData["minute"] as? Number)?.toInt() ?: 0
         val gameType = alarmData["gameType"] as? String ?: "piano_tiles"
         val selectedDays = alarmData["selectedDays"] as? List<Int> ?: emptyList()
+        val durationMinutes = (alarmData["durationMinutes"] as? Number)?.toInt() ?: 1
 
         Log.d(TAG, "Scheduling native alarm: $name at $hour:$minute with game: $gameType, selectedDays: $selectedDays")
 
         val alarmItem = AlarmItem(
             id = id,
             message = name,
-            gameType = gameType
+            gameType = gameType,
+            durationMinutes = durationMinutes
         )
 
         val now = java.util.Calendar.getInstance()

--- a/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/activity/AlarmActivity.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/activity/AlarmActivity.kt
@@ -74,6 +74,7 @@ class AlarmActivity : ComponentActivity() {
         val alarmId = intent.getIntExtra("ALARM_ID", -1)
         val alarmTime = intent.getLongExtra("ALARM_TIME", System.currentTimeMillis())
         val gameType = intent.getStringExtra("ALARM_GAME_TYPE") ?: "piano_tiles"
+        val durationMinutes = intent.getIntExtra("ALARM_DURATION_MINUTES", 1)
 
         // Initialize volume control
         initializeVolumeControl()
@@ -139,7 +140,8 @@ class AlarmActivity : ComponentActivity() {
                             // Pass alarm time and gameType through method channel and navigate
                             val alarmArgs = mapOf(
                                 "alarmTime" to alarmTime,
-                                "gameType" to gameType
+                                "gameType" to gameType,
+                                "durationMinutes" to durationMinutes
                             )
                             channel.invokeMethod("navigateToAlarmGame", alarmArgs)
                             
@@ -147,7 +149,8 @@ class AlarmActivity : ComponentActivity() {
                             val intent = Intent(this@AlarmActivity, AlarmFlutterActivity::class.java).apply {
                                 putExtra("alarmTime", alarmTime)
                                 putExtra("gameType", gameType)
-                                flags = Intent.FLAG_ACTIVITY_NEW_TASK or 
+                                putExtra("durationMinutes", durationMinutes)
+                                flags = Intent.FLAG_ACTIVITY_NEW_TASK or
                                        Intent.FLAG_ACTIVITY_CLEAR_TOP or
                                        Intent.FLAG_ACTIVITY_NO_ANIMATION or
                                        Intent.FLAG_ACTIVITY_SINGLE_TOP or

--- a/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/activity/AlarmFlutterActivity.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/activity/AlarmFlutterActivity.kt
@@ -19,7 +19,9 @@ class AlarmFlutterActivity : FlutterActivity() {
     }
 
     override fun getInitialRoute(): String? {
-        return "/alarm_game"
+        val gameType = intent.getStringExtra("gameType") ?: "piano_tiles"
+        val durationMinutes = intent.getIntExtra("durationMinutes", 1)
+        return "/alarm_game?gameType=$gameType&durationMinutes=$durationMinutes"
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {

--- a/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/alarmScheduler/AlarmSchedulerImpl.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/alarmScheduler/AlarmSchedulerImpl.kt
@@ -33,6 +33,7 @@ class AlarmSchedulerImpl(private val context: Context) : AlarmScheduler {
             putExtra("ALARM_ID", alarmItem.id)
             putExtra("ALARM_MESSAGE", alarmItem.message)
             putExtra("ALARM_GAME_TYPE", alarmItem.gameType)
+            putExtra("ALARM_DURATION_MINUTES", alarmItem.durationMinutes)
         }
         
         val pendingIntent = PendingIntent.getBroadcast(
@@ -62,6 +63,7 @@ class AlarmSchedulerImpl(private val context: Context) : AlarmScheduler {
             putLong("alarm_${alarmItem.id}_time", triggerTime)
             putString("alarm_${alarmItem.id}_message", alarmItem.message)
             putString("alarm_${alarmItem.id}_game", alarmItem.gameType)
+            putInt("alarm_${alarmItem.id}_duration", alarmItem.durationMinutes)
             putBoolean("alarm_${alarmItem.id}_active", true)
             apply()
         }
@@ -93,6 +95,7 @@ class AlarmSchedulerImpl(private val context: Context) : AlarmScheduler {
             remove("alarm_${alarmItem.id}_time")
             remove("alarm_${alarmItem.id}_message")
             remove("alarm_${alarmItem.id}_game")
+            remove("alarm_${alarmItem.id}_duration")
             remove("alarm_${alarmItem.id}_active")
             apply()
         }

--- a/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/model/AlarmItem.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/model/AlarmItem.kt
@@ -3,5 +3,6 @@ package com.example.flutter_alarm_manager_poc.model
 data class AlarmItem(
     val id: Int,
     val message: String,
-    val gameType: String = "piano_tiles"
+    val gameType: String = "piano_tiles",
+    val durationMinutes: Int = 1
 )

--- a/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/receiver/AlarmReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/receiver/AlarmReceiver.kt
@@ -35,6 +35,7 @@ class AlarmReceiver : BroadcastReceiver() {
         val alarmId = intent?.getIntExtra("ALARM_ID", -1) ?: -1
         val message = intent?.getStringExtra("ALARM_MESSAGE") ?: "Alarm!"
         val gameType = intent?.getStringExtra("ALARM_GAME_TYPE") ?: "piano_tiles"
+        val durationMinutes = intent?.getIntExtra("ALARM_DURATION_MINUTES", 1) ?: 1
         val alarmTime = System.currentTimeMillis()
         
         Log.d(TAG, "Alarm triggered - ID: $alarmId, Message: $message, Game: $gameType, Time: $alarmTime")
@@ -44,6 +45,7 @@ class AlarmReceiver : BroadcastReceiver() {
             putExtra("ALARM_ID", alarmId)
             putExtra("ALARM_MESSAGE", message)
             putExtra("ALARM_GAME_TYPE", gameType)
+            putExtra("ALARM_DURATION_MINUTES", durationMinutes)
             putExtra("ALARM_TIME", alarmTime)
         }
 
@@ -56,7 +58,7 @@ class AlarmReceiver : BroadcastReceiver() {
 
         val notificationService: AlarmNotificationService = AlarmNotificationServiceImpl(context)
         notificationService.showNotification(
-            alarmItem = AlarmItem(alarmId, message),
+            alarmItem = AlarmItem(alarmId, message, gameType, durationMinutes),
             alarmTime = alarmTime,
             fullScreenPendingIntent = fullScreenPendingIntent
         )

--- a/lib/alarm_game_screen.dart
+++ b/lib/alarm_game_screen.dart
@@ -47,24 +47,17 @@ class _AlarmGameScreenState extends State<AlarmGameScreen> {
   @override
   void initState() {
     super.initState();
-    // Nie używaj context tutaj!
-    // Pozostała inicjalizacja
-    print('AlarmGameScreen: initState called');
+    durationMinutes = widget.durationMinutes;
+    remainingSeconds = durationMinutes * 60;
+    print("AlarmGameScreen: initState called, durationMinutes: $durationMinutes");
     _startAlarmSystem();
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    // Pobierz durationMinutes z argumentów, jeśli dostępne
-    final args = ModalRoute.of(context)?.settings.arguments as Map<String, dynamic>?;
-    if (args != null && args['durationMinutes'] != null) {
-      durationMinutes = args['durationMinutes'] as int;
-      remainingSeconds = durationMinutes * 60;
-      print('AlarmGameScreen: didChangeDependencies called, durationMinutes: $durationMinutes');
-    }
+    // No additional initialization required here
   }
-
   void _startAlarm() async {
     print('AlarmGameScreen: _startAlarm called');
     

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -138,11 +138,13 @@ class _MyAppState extends State<MyApp> {
               if (uri.path == '/alarm_game') {
                 final alarmTimeParam = uri.queryParameters['alarmTime'];
                 final gameTypeParam = uri.queryParameters['gameType'];
-                
+                final durationParam = uri.queryParameters['durationMinutes'];
+
                 if (alarmTimeParam != null && gameTypeParam != null) {
                   args = {
                     'alarmTime': int.tryParse(alarmTimeParam) ?? DateTime.now().millisecondsSinceEpoch,
                     'gameType': gameTypeParam,
+                    'durationMinutes': int.tryParse(durationParam ?? '1') ?? 1,
                   };
                 }
               }

--- a/lib/services/alarm_scheduler_service.dart
+++ b/lib/services/alarm_scheduler_service.dart
@@ -121,6 +121,7 @@ class AlarmSchedulerService {
       'hour': alarm.hour,
       'minute': alarm.minute,
       'gameType': alarm.gameType,
+      'durationMinutes': alarm.durationMinutes,
       'selectedDays': alarm.selectedDays.toList(),
     });
   }

--- a/lib/utils/alarm_method_channel.dart
+++ b/lib/utils/alarm_method_channel.dart
@@ -29,7 +29,7 @@ class AlarmMethodChannel {
 
   static Future<void> scheduleNativeAlarm(Map<String, dynamic> alarmData) async {
     try {
-      log(name: name, 'Scheduling native alarm: ${alarmData['name']} at ${alarmData['hour']}:${alarmData['minute']} with game: ${alarmData['gameType']}');
+      log(name: name, 'Scheduling native alarm: ${alarmData['name']} at ${alarmData['hour']}:${alarmData['minute']} with game: ${alarmData['gameType']} for ${alarmData['durationMinutes']} min');
       await platform.invokeMethod('scheduleNativeAlarm', alarmData);
       log(name: name, 'Native alarm scheduled successfully');
     } on PlatformException catch (e) {


### PR DESCRIPTION
## Summary
- add `durationMinutes` to `AlarmItem`
- pass game type and duration from Kotlin intents to Flutter
- store duration in AlarmScheduler and forward via notification
- read query parameters for duration in Flutter routing
- initialize `AlarmGameScreen` with duration from widget

## Testing
- `git diff --cached --stat`


------
https://chatgpt.com/codex/tasks/task_e_687e9ecf7dd88330a163c6f4c7351dc4