### PR TITLE
Fix alarm screen not showing

### DIFF
--- a/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/receiver/AlarmReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_alarm_manager_poc/receiver/AlarmReceiver.kt
@@ -63,5 +63,15 @@ class AlarmReceiver : BroadcastReceiver() {
             fullScreenPendingIntent = fullScreenPendingIntent
         )
         Log.d(TAG, "Notification with full-screen intent shown")
+
+        // Explicitly start the AlarmActivity to ensure the UI is displayed
+        // even if the system does not automatically launch the full-screen
+        // intent (which can happen on some devices when the screen is locked).
+        try {
+            context.startActivity(fullScreenIntent)
+            Log.d(TAG, "AlarmActivity started explicitly from receiver")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start AlarmActivity: ${e.message}")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- start AlarmActivity directly when receiving the alarm broadcast

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68892d8bf7f48330b6d0e72fe477b4c0